### PR TITLE
FEAT: Add maze generator

### DIFF
--- a/internal/app/maze/maze.go
+++ b/internal/app/maze/maze.go
@@ -1,8 +1,7 @@
 package maze
 
 import (
-	"math/rand/v2"
-
+	"github.com/Kaamkiya/gg/internal/app/maze/mazegenerator"
 	tea "github.com/charmbracelet/bubbletea"
 )
 
@@ -18,18 +17,19 @@ type model struct {
 }
 
 func initialModel() tea.Model {
-	maze := mazes[rand.IntN(len(mazes))]
+	// maze := mazes[rand.IntN(len(mazes))]
+	maze := mazegenerator.GenerateMaze(20, 20, "prim")
 
 	startpos := vector{}
 	endpos := vector{}
 
-	for y := range maze {
-		for x := range maze[y] {
-			if maze[y][x] == 'S' {
+	for y := range maze.Grid {
+		for x := range maze.Grid[y] {
+			if maze.Get(x, y) == 'S' {
 				startpos.x = y
 				startpos.y = x
 			}
-			if maze[y][x] == 'E' {
+			if maze.Get(x, y) == 'E' {
 				endpos.x = y
 				endpos.y = x
 			}
@@ -37,7 +37,7 @@ func initialModel() tea.Model {
 	}
 
 	return model{
-		maze:   maze,
+		maze:   maze.Grid,
 		pos:    startpos,
 		endpos: endpos,
 	}
@@ -121,7 +121,8 @@ func (m *model) MovePlayer(dir string) {
 }
 
 func Run() {
-	p := tea.NewProgram(initialModel())
+	// TODO: Testing
+	p := tea.NewProgram(mazegenerator.GetModel())
 
 	if _, err := p.Run(); err != nil {
 		panic(err)

--- a/internal/app/maze/maze.go
+++ b/internal/app/maze/maze.go
@@ -17,8 +17,7 @@ type model struct {
 }
 
 func initialModel() tea.Model {
-	// maze := mazes[rand.IntN(len(mazes))]
-	maze := mazegenerator.GenerateMaze(20, 20, "prim")
+	maze := mazegenerator.GenerateMaze(25, 15, "prim")
 
 	startpos := vector{}
 	endpos := vector{}
@@ -121,8 +120,7 @@ func (m *model) MovePlayer(dir string) {
 }
 
 func Run() {
-	// TODO: Testing
-	p := tea.NewProgram(mazegenerator.GetModel())
+	p := tea.NewProgram(initialModel())
 
 	if _, err := p.Run(); err != nil {
 		panic(err)

--- a/internal/app/maze/mazegenerator/generator.go
+++ b/internal/app/maze/mazegenerator/generator.go
@@ -1,0 +1,68 @@
+package mazegenerator
+
+import (
+	"math/rand"
+)
+
+type MazeGenerator interface {
+	Generate(maze *Maze)
+}
+
+func NewMazeGenerator(generator string) MazeGenerator {
+	switch generator {
+	case "prim":
+		return &PrimGenerator{}
+	default:
+		return &PrimGenerator{}
+	}
+}
+
+type PrimGenerator struct {
+}
+
+func (p *PrimGenerator) Generate(maze *Maze) {
+	startX, startY := maze.GetStartPos()
+
+	walls := maze.GetNeighbors(startX, startY, true)
+
+	curr := Cell{startX, startY}
+
+	for len(walls) > 0 {
+		// Choose a random wall
+		randIdx := rand.Intn(len(walls))
+
+		// Pop the wall
+		wall := walls[randIdx]
+		walls = append(walls[:randIdx], walls[randIdx+1:]...)
+
+		if maze.Get(wall.x, wall.y) == PATH {
+			continue
+		}
+
+		paths := maze.GetNeighbors(wall.x, wall.y, false)
+		if len(paths) >= 2 || len(paths) == 0 {
+			continue
+		}
+		path := paths[rand.Intn(len(paths))]
+
+		// Get opposite cell of the path
+		nextX, nextY := wall.x+(wall.x-path.x), wall.y+(wall.y-path.y)
+		next := Cell{nextX, nextY}
+		maze.MakePath(wall)
+
+		if maze.IsInner(next.x, next.y) {
+			maze.MakePath(next)
+			// Add walls
+			walls = append(walls, maze.GetNeighbors(next.x, next.y, true)...)
+		} else {
+			walls = append(walls, maze.GetNeighbors(wall.x, wall.y, true)...)
+			// find the longest path on the boundary
+			if next.Diff(curr) > curr.Diff(curr) {
+				curr = next
+			}
+		}
+
+	}
+
+	maze.SetEnd(curr.x, curr.y)
+}

--- a/internal/app/maze/mazegenerator/maze.go
+++ b/internal/app/maze/mazegenerator/maze.go
@@ -1,0 +1,109 @@
+package mazegenerator
+
+import (
+	"fmt"
+	"math/rand"
+)
+
+const (
+	WALL  = '#'
+	PATH  = ' '
+	START = 'S'
+	END   = 'E'
+)
+
+type Cell struct {
+	x, y int
+}
+
+var DIRS = []Cell{{1, 0}, {0, 1}, {-1, 0}, {0, -1}}
+
+func (c Cell) Diff(other Cell) int {
+	return (c.x-other.x)*(c.x-other.x) + (c.y-other.y)*(c.y-other.y)
+}
+
+type Maze struct {
+	Width, Height int
+	Start, End    Cell
+	Grid          [][]rune
+}
+
+func NewMaze(width, height int) *Maze {
+	grid := make([][]rune, height)
+
+	for i := range grid {
+		grid[i] = make([]rune, width)
+		for j := range grid[i] {
+			grid[i][j] = WALL
+		}
+	}
+
+	startX := rand.Intn(width/4) + 1
+	startY := rand.Intn(height/4) + 1
+
+	grid[startY][startX] = START
+
+	return &Maze{
+		Width:  width,
+		Height: height,
+		Start:  Cell{startX, startY},
+		Grid:   grid,
+	}
+}
+
+func (m *Maze) Set(x, y int, val rune) {
+	m.Grid[y][x] = val
+}
+
+func (m Maze) Get(x, y int) rune {
+	return m.Grid[y][x]
+}
+
+func (m Maze) GetStartPos() (x, y int) {
+	return m.Start.x, m.Start.y
+}
+
+func (m Maze) GetEndPos() (x, y int) {
+	return m.End.x, m.End.y
+}
+
+func (m *Maze) SetEnd(x, y int) {
+	m.Grid[y][x] = END
+	m.End = Cell{x, y}
+}
+
+func (m Maze) IsInner(x, y int) bool {
+	return x > 0 && x < m.Width-1 && y > 0 && y < m.Height-1
+}
+
+func (m Maze) IsWall(x, y int) bool {
+	return m.Grid[y][x] == WALL
+}
+
+func (m Maze) GetNeighbors(x, y int, findWall bool) []Cell {
+	var neighbors []Cell
+	for _, dir := range DIRS {
+		dx, dy := x+dir.x, y+dir.y
+		if !m.IsInner(dx, dy) {
+			continue
+		}
+		if findWall == m.IsWall(dx, dy) {
+			neighbors = append(neighbors, Cell{dx, dy})
+		}
+	}
+
+	return neighbors
+}
+
+func (m *Maze) MakePath(cell Cell) {
+	m.Set(cell.x, cell.y, PATH)
+}
+
+func (m Maze) Print() {
+	for _, row := range m.Grid {
+		for _, cell := range row {
+			fmt.Printf("%c", cell)
+		}
+		fmt.Println()
+	}
+}

--- a/internal/app/maze/mazegenerator/mazegenerator.go
+++ b/internal/app/maze/mazegenerator/mazegenerator.go
@@ -1,0 +1,9 @@
+package mazegenerator
+
+func GenerateMaze(width, height int, algorithm string) *Maze {
+	maze := NewMaze(width, height)
+	generator := NewMazeGenerator(algorithm)
+	generator.Generate(maze)
+
+	return maze
+}

--- a/internal/app/maze/mazegenerator/model.go
+++ b/internal/app/maze/mazegenerator/model.go
@@ -1,0 +1,62 @@
+package mazegenerator
+
+import tea "github.com/charmbracelet/bubbletea"
+
+type MazeModel struct {
+	maze *Maze
+}
+
+func GetModel() tea.Model {
+	maze := GenerateMaze(30, 20, "prim")
+
+	return MazeModel{
+		maze,
+	}
+}
+
+func (m MazeModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m MazeModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "q":
+			return m, tea.Quit
+		case "g":
+			m.generate()
+		}
+	}
+
+	return m, nil
+}
+
+func (m MazeModel) View() string {
+	s := "\n"
+
+	startX, startY := m.maze.GetStartPos()
+
+	for i, row := range m.maze.Grid {
+		for j := range m.maze.Grid[i] {
+			if i == startX && j == startY {
+				s += "@"
+			} else if row[j] == 'E' {
+				s += "X"
+			} else if row[j] == '#' {
+				s += string(rune(9608))
+			} else {
+				s += " "
+			}
+		}
+		s += "\n"
+	}
+
+	s += "\n[G]enerate new maze \n"
+
+	return s
+}
+
+func (m *MazeModel) generate() {
+	m.maze = GenerateMaze(30, 20, "prim")
+}

--- a/internal/app/maze/mazegenerator/model.go
+++ b/internal/app/maze/mazegenerator/model.go
@@ -6,8 +6,14 @@ type MazeModel struct {
 	maze *Maze
 }
 
+const (
+	width  = 30
+	height = 20
+	algo   = "prim"
+)
+
 func GetModel() tea.Model {
-	maze := GenerateMaze(30, 20, "prim")
+	maze := GenerateMaze(width, height, algo)
 
 	return MazeModel{
 		maze,
@@ -58,5 +64,5 @@ func (m MazeModel) View() string {
 }
 
 func (m *MazeModel) generate() {
-	m.maze = GenerateMaze(30, 20, "prim")
+	m.maze = GenerateMaze(width, height, algo)
 }


### PR DESCRIPTION
- Added Prim's algorithm to auto-generate mazes

## Description
I added a new package `mazegenerator` with the following structure:
- `Maze` to represent 2d grid - `mazegenerator/maze.go`
- `MazeGenerator` interface for extensibility
- `PrimGenerator` - main algorithm
- `mazegenerator/model.go` contains `tea.Model` for visualization

## Motivation and Context
- Issue #4 

## Screenshots: 
> I only tested visually. These are generated mazes on a 30x20 grid
> I also placed the endpoint on the border to look like an exit. Let me know if it's ok.

![mazegenerator-demo2](https://github.com/user-attachments/assets/d9820315-56f6-4bc0-8fc0-864c9fd3fa20)

> Feel free to suggest any changes or improvements.

## Types of changes
- [x] New feature (non-breaking change which adds functionality))

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

