### PR TITLE
Allow players to force a drop with pressing down twice

### DIFF
--- a/internal/app/tetris/gameloop.go
+++ b/internal/app/tetris/gameloop.go
@@ -26,7 +26,10 @@ func initialModel() gameState {
 			initialGameProgressTickDelay,
 		},
 		false,
-		dropFinished,
+		pieceDrop{
+			dropFinished,
+			false,
+		},
 	}
 }
 
@@ -53,7 +56,7 @@ func (gs *gameState) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case "l", "L", "right":
 				gs.handleRight()
 			case "j", "J", "down":
-				gs.handleDrop()
+				return gs, gs.handleDrop()
 			case "z", "Z":
 				gs.handleLeftRotate()
 			case "x", "X":
@@ -70,6 +73,12 @@ func (gs *gameState) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	case gameProgressTick:
 		if gs.isPaused {
+			return gs, nil
+		}
+
+		// Skip a tick as droping a force scheduled a new one
+		if gs.pieceDrop.dropForced {
+			gs.pieceDrop.dropForced = false
 			return gs, nil
 		}
 		return gs, gs.handleGameProgressTick()

--- a/internal/app/tetris/gamestate_test.go
+++ b/internal/app/tetris/gamestate_test.go
@@ -20,7 +20,10 @@ func TestASingleLineIsRemoved(t *testing.T) {
 			300,
 		},
 		false,
-		dropFinished,
+		pieceDrop{
+			dropFinished,
+			false,
+		},
 	}
 
 	for i := range width {
@@ -49,7 +52,10 @@ func TestMultipleLinesAreRemoved(t *testing.T) {
 			300,
 		},
 		false,
-		dropFinished,
+		pieceDrop{
+			dropFinished,
+			false,
+		},
 	}
 
 	for i := range width {


### PR DESCRIPTION
## Description
With the previous implementation of dropping a piece, I found it a bit frustrating that when you pressed the down button twice, nothing happened. I would expect that when I pressed down a second time, it would drop the piece completely.

This PR implements that change. Now players can complete the drop immediately. 

## How has this been tested?
No tests, just tried it out.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

