### PR TITLE
Improved 2048 Tile Handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.out
 go.work
 /gg
+.DS_Store

--- a/internal/app/tetris/line_animation.go
+++ b/internal/app/tetris/line_animation.go
@@ -74,4 +74,3 @@ func (gs *gameState) handleLineAnimationTick(animationTick lineAnimationTick) te
 		}
 	})
 }
-


### PR DESCRIPTION
## Description
- Fixes the "edge case" mentioned on line 60~71. The game no longer ends when the board is full, but a move is still possible.

- Issue https://github.com/Kaamkiya/gg/issues/11 has been patched. Tiles no longer spawn in when a player moves without any tiles actually moving.

- Any other *.go files included are due to the formatting command per the contributing guide.

## Motivation and Context
This PR patches this issue: https://github.com/Kaamkiya/gg/issues/11

## How has this been tested?
1. Boot up "gg" in a terminal and select "2048".
2. Once the game has been selected, the following fixes should be present:
- No longer lose when all tiles are full (unless no merges are available)
- No longer spawn a new number tile unless a move is made

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Feel free to squash merge this. I only made a single commit, but I created a new branch when it would've been fine on main.**