### PR TITLE
Fix malformed next shape preview

### DIFF
--- a/internal/app/tetris/gameloop.go
+++ b/internal/app/tetris/gameloop.go
@@ -168,14 +168,14 @@ func buildSidebar(gs *gameState) [14]string {
 				sidebarLines[i+2] = "                      "
 			} else {
 				lineBuilder := strings.Builder{}
-				spaceLength := (22 - len(grid[i])) / 2
+				spaceLength := (22 - len(grid[i])) / 2 - 1
 				lineBuilder.WriteString(strings.Repeat(" ", spaceLength))
 
 				for j := range grid[i] {
 					if grid[i][j] {
-						lineBuilder.WriteString(gs.gameBoard.Colors[gs.nextShape.GetColor()].Render(" "))
+						lineBuilder.WriteString(gs.gameBoard.Colors[gs.nextShape.GetColor()].Render("  "))
 					} else {
-						lineBuilder.WriteString(" ")
+						lineBuilder.WriteString("  ")
 					}
 				}
 				lineBuilder.WriteString(strings.Repeat(" ", spaceLength))


### PR DESCRIPTION
## Description

Changes how next shape is rendered in the tetris game.

## Motivation and Context
The next shape preview in tetris looked kind of squashed.

## How has this been tested?
- I've played the tetris game
- I've run `go test ./...`

## Screenshots (if appropriate):

### Before

<img width="654" height="832" alt="image" src="https://github.com/user-attachments/assets/b79069c7-3cf7-4996-8ab5-7f918834a25d" />

### After

<img width="687" height="833" alt="image" src="https://github.com/user-attachments/assets/0e4e974d-a373-4dba-aa09-adb745bd01bd" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] ~~All~~ new and existing tests passed. - it looks like "sudokugenerator" tests are failing at build stage, but it's nothing I've touched
