### PR TITLE
[sudoku] Add clearing a square and resetting entire grid

### DIFF
--- a/internal/app/sudoku/sudoku.go
+++ b/internal/app/sudoku/sudoku.go
@@ -44,6 +44,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.cursorx < 8 {
 				m.cursorx++
 			}
+		case "backspace", ".":
+			m.setSquare("0")
+		case "r":
+			m.resetGrid()
 		case "1", "2", "3", "4", "5", "6", "7", "8", "9", "0":
 			m.setSquare(msg.String())
 		}
@@ -84,12 +88,26 @@ func (m model) View() string {
 		}
 	}
 
+	s += "hjkl/←↓↑→ to move\n"
+	s += "1-9 to set a square\n"
+	s += "backspace or . to clear a square\n"
+	s += "r to reset the grid\n"
+	s += "q to quit"
+
 	return s
 }
 
 func (m *model) setSquare(button string) {
 	if m.origGrid[m.cursory][m.cursorx] == 0 {
 		m.grid[m.cursory][m.cursorx], _ = strconv.Atoi(button)
+	}
+}
+
+func (m *model) resetGrid() {
+	m.grid = make([][]int, 9)
+	for i := range 9 {
+		m.grid[i] = make([]int, 9)
+		copy(m.grid[i], m.origGrid[i])
 	}
 }
 


### PR DESCRIPTION
## Description
Adds clear and reset functionality to the sudoku game
- backspace/. - clears a space
- r - resets everything

## Motivation and Context
As suggested in #31 

## How has this been tested?
1.
```bash
$ go test ./...
```
2. Playing the game shortly

## Screenshots (if appropriate):

<img width="323" height="328" alt="image" src="https://github.com/user-attachments/assets/7b50491a-9b71-4b29-a4a7-f3b3f7ad2b78" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

